### PR TITLE
Introduce HomeMap component

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,11 @@ RewriteRule ^ /index.html [L]
 User-agent: *
 Disallow:
 ```
+
+### Map component architecture
+
+The homepage map is now grouped in a dedicated `HomeMap` component that brings
+`worldMap.vue` and `mapData.vue` together. The container exposes a single
+`project-selected` event and receives the resources collection along with an
+optional `activeCountry` prop. This encapsulation keeps the page markup simpler
+and lets the map cluster evolve independently.

--- a/components/HomeMap.vue
+++ b/components/HomeMap.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="home-map">
+    <WorldMap class="map" />
+    <MapData
+      class="data"
+      :resources="resources"
+      :activeCountry="activeCountry"
+      @project-selected="handleProjectSelected"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import WorldMap from './worldMap.vue'
+import MapData from './mapData.vue'
+
+const props = defineProps({
+  resources: {
+    type: Object,
+    required: true,
+    default: () => ({})
+  },
+  activeCountry: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['project-selected'])
+const handleProjectSelected = (payload: any) => emit('project-selected', payload)
+</script>
+
+<style scoped lang="scss">
+.home-map {
+  position: relative;
+}
+.home-map > .data {
+  position: absolute;
+  inset: 0;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,8 +69,11 @@
             <p><a href="https://idrc-crdi.ca/en/initiative/gender-stem" target="_blank">Breaking Barriers Network</a></p>
         </div>-->
         <div class="map-grid__map">
-          <world-map class="map" />
-          <map-data class="data" :resources="resources" :activeCountry="data.selectedCountry" @project-selected="handleProjectSelected" />
+          <HomeMap
+            :resources="resources"
+            :activeCountry="data.selectedCountry"
+            @project-selected="handleProjectSelected"
+          />
         </div>
         <div class="map-grid__content">  
           <resource-list :resources="data.resourceList" />


### PR DESCRIPTION
## Summary
- add `HomeMap` container component to group the map pieces
- swap world-map + map-data usage for `HomeMap`
- document the new map architecture

## Testing
- `npm run lint` *(fails: several lint errors across repo)*