### PR TITLE
Fix clear filter function

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -424,6 +424,9 @@ const handleClickOutside = (event: MouseEvent) => {
 };
 
 function clearFilter() {
+  activeCountry.value = null
+  filteredResourceList.value = resourceFullList
+  data.resourceList = filteredResourceList.value
   data.selectedCountry = ''
 }
 


### PR DESCRIPTION
## Summary
- restore default resources list when clearing filters

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_683a76ed459c832290eab189f23bba3f