### PR TITLE
Fix signup section

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -198,17 +198,6 @@
                     </li>
                   </ul>
                 </template>
-                <!-- Sign Up -->
-                <!--<template #sign-up>
-      <twin-section class="sign-up">
-        <template #left>
-          <h2>Sign Up</h2>
-        </template>
-        <template #right>
-          <h2>Sign Up</h2>
-        </template> 
-      </twin-section>
-    </template>-->
 
                 <!-- Hero -->
                 <template #hero>
@@ -324,6 +313,9 @@
       </template>
       <template #challenge>
         <challenge-section />
+      </template>
+      <template #sign-up>
+        <signup-section />
       </template>
       <template #footer>
         <footer-section />


### PR DESCRIPTION
## Summary
- restore the signup section on the homepage by adding it back into the layout

## Testing
- `npm run lint` *(fails: import order and unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_b_683a7748f01483229869ef7388efe229